### PR TITLE
fix: fix git repo validation

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,7 +23,7 @@ const options = program.opts();
 const branch = options.test || currentBranchName;
 
 // validate whether it is a git repository
-if (!options.branch && !currentBranchName) {
+if (!branch) {
   console.error('\x1b[31m%s\x1b[0m', 'Error: not a git repository\n');
   process.exitCode = FAILED_CODE;
   return;


### PR DESCRIPTION
### Current Behavior:
Calling `npx validate-branch-name -t $CI_COMMIT_REF_NAME` in a gitlab-ci pipeline throws `Error: not a git repository`
This is because an invalid condition that this PR tries to fix...

### Expected behavior:
Command should execute without errors