### PR TITLE
feat: introduce dependabot for dependency version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+version: 2
+updates:
+  # Daily: Check minor and patch updates
+  - package-ecosystem: "npm"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "CST"
+    # https://github.com/dependabot/dependabot-core/issues/5226#issuecomment-1179434437
+    versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
     schedule:
       interval: "daily"
       time: "02:00"
-      timezone: "CST"
+      timezone: "Asia/Shanghai"
     # https://github.com/dependabot/dependabot-core/issues/5226#issuecomment-1179434437
     versioning-strategy: increase


### PR DESCRIPTION
As you're using some `dependencies` these should get updated which would be the easiest by having dependabot open PRs for this.